### PR TITLE
webos generic bash build script added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+packages

--- a/.palmignore
+++ b/.palmignore
@@ -1,0 +1,5 @@
+.*
+packages
+package.sh
+devdeploy.sh
+enyo

--- a/devdeploy.sh
+++ b/devdeploy.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+REMOVE=$1
+if [ "$REMOVE" = "-r" ]; then
+  palm-install -r com.funkatron.app.spaz-hd
+fi
+./package.sh
+VERSION=`cat appinfo.json | egrep -o '"version":\s"([^"]*)"' | sed -r 's/"version":\s"([^"]*)"/\1/'`
+PACKAGE_NAME="com.funkatron.app.spaz-hd_"$VERSION"_all.ipk"
+palm-install packages/$PACKAGE_NAME
+palm-launch com.funkatron.app.spaz-hd

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+cd vendors
+cp spazcore-standard.js spazcore.js
+cd ..
+git checkout master
+mkdir packages
+palm-package -o ./packages -X ./.palmignore --ignore-case ./


### PR DESCRIPTION
added a generic build script for webos - just run './devdeploy.sh' or './devdeploy.sh -r' with the emulator running;
the -r option removes the package from the emulator first if you want to test a clean-install scenario;
